### PR TITLE
correctly assign expressions where brackets are used & the middle val is undefined

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -725,7 +725,9 @@ Parser.prototype = {
       return getter(self || object(scope, locals));
     }, {
       assign: function(scope, value, locals) {
-        return setter(object(scope, locals), field, value, parser.text, parser.options);
+        var o = object(scope, locals);
+        if (!o) object.assign(scope, o = {}, locals);
+        return setter(o, field, value, parser.text, parser.options);
       }
     });
   },
@@ -748,8 +750,9 @@ Parser.prototype = {
       assign: function(self, value, locals) {
         var key = indexFn(self, locals);
         // prevent overwriting of Function.constructor which would break ensureSafeObject check
-        var safe = ensureSafeObject(obj(self, locals), parser.text);
-        return safe[key] = value;
+        var o = ensureSafeObject(obj(self, locals), parser.text);
+        if (!o) obj.assign(self, o = [], locals);
+        return o[key] = value;
       }
     });
   },

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "mocha": "1.x",
     "chai": "1.x",
     "webpack-dev-server": "1.x",
-    "mocha-loader": "0.x"
+    "mocha-loader": "0.6.4"
   },
   "repository": {
     "type": "git",

--- a/test/main.test.js
+++ b/test/main.test.js
@@ -199,24 +199,6 @@ describe("expressions", function () {
                 expect(scope.ships[0].pirate).to.equal("Störtebeker");
             });
 
-            it("should throw an error if the array doesn't exist", function () {
-                var obj,
-                    err;
-
-                try {
-                    // first we're creating the same type of error because the error messages differ
-                    // between javascript implementations
-                    obj.pirate;
-                } catch (e) {
-                    err = e;
-                }
-
-                evaluate = compile("ships[0].pirate.name = 'Jenny'");
-                expect(function () {
-                    evaluate(scope);
-                }).to.throw(err.message);
-            });
-
         });
 
         describe("when evaluating function calls", function () {
@@ -425,6 +407,34 @@ describe("expressions", function () {
                     compile.cache = {};
                 });
 
+            });
+
+        });
+
+        describe("assignable", function() {
+
+            it("should expose assignment function", function() {
+                var fn = compile("a");
+                expect(fn.assign).to.be.a("function");
+                var scope = {};
+                fn.assign(scope, 123);
+                expect(scope.a).to.equal(123);
+            });
+
+            it('should expose working assignment function for expressions ending with brackets', function() {
+                var fn = compile('a.b["c"]');
+                expect(fn.assign).to.be.a("function");
+                var scope = {};
+                fn.assign(scope, 123);
+                expect(scope.a.b.c).to.equal(123);
+            });
+
+            it('should expose working assignment function for expressions with brackets in the middle', function() {
+                var fn = compile('a["b"].c');
+                expect(fn.assign).to.be.a("function");
+                var scope = {};
+                fn.assign(scope, 123);
+                expect(scope.a.b.c).to.equal(123);
             });
 
         });


### PR DESCRIPTION
This incorporates the changes in angular.js from https://github.com/angular/angular.js/commit/c03ad2490