### PR TITLE
Fixed typings

### DIFF
--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -23,6 +23,8 @@ type CompileFunc = {
   };
 };
 
+type FilterFunction = (input: any, ...args: any[]) => any;
+
 export const compile: CompileFunc;
 
 export class Lexer {
@@ -30,9 +32,13 @@ export class Lexer {
 }
 
 export const filters: {
-  [x: string]: (input: any, ...args: any[]) => any;
+  [x: string]: FilterFunction;
 };
 
 export class Parser {
-  constructor(options?: ParserOptions);
+  constructor(
+    lexer: Lexer,
+    filterFunction: (tag: any) => FilterFunction,
+    options?: ParserOptions
+  );
 }

--- a/lib/main.test-d.ts
+++ b/lib/main.test-d.ts
@@ -1,9 +1,13 @@
 import expressions from "./main.js";
 import { filters } from "./main.js";
 
-const { Parser } = expressions;
+const { Parser, Lexer } = expressions;
 
-const ppp = new Parser({ csp: true });
+function getFilters(tag: any) {
+  return filters[tag];
+}
+
+const ppp = new Parser(new Lexer(), getFilters, { csp: true });
 const f = expressions.compile("x + 1");
 const myResult = f.assign({}, 123);
 


### PR DESCRIPTION
Currently the typings for `Parser` are incorrect. This MR should fix the type definitions.