### PR TITLE
isolate filters object

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,2 +1,1 @@
 trailingComma: es5
-singleQuote: false

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,1 +1,2 @@
 trailingComma: es5
+singleQuote: false

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ expr({
 }); // returns '1.23€'
 ```
 
-If you need an isolated `filters` object, this can be achieved by setting the `filters` attribute in the `options` argument. Global cache is disabled if using `options.filters`. To setup an isolated cache, you can also set a `cache` object in the `options` argument. It can then be used to speed up subsequent calls:
+If you need an isolated `filters` object, this can be achieved by setting the `filters` attribute in the `options` argument. Global cache is disabled if using `options.filters`. To setup an isolated cache, you can also set the `cache` attribute in the `options` argument:
 
 ```javascript
 var isolatedFilters = {
@@ -86,7 +86,7 @@ var resultOne = expressions.compile("'Foo Bar' | transform", {
   cache: isolatedCache,
 });
 
-console.log(resultOne()); // prints 'foo bar'
+console.log(resultOne());   // prints 'foo bar'
 console.log(isolatedCache); // print '{"'Foo Bar' | transform": [Function fn] }'
 ```
 

--- a/README.md
+++ b/README.md
@@ -73,6 +73,23 @@ expr({
 }); // returns '1.23€'
 ```
 
+Also if you need independent filter object for e.g. tenant isolation, this can be achieved by creating an instance of the `AngularExpressions` object:
+
+```javascript
+var expressionsInstance = new AngularExpressions({
+  transform: (input) => input.toLowerCase()
+});
+var anotherExpressionsInstance = new AngularExpressions({
+  transform: (input) => input.toUpperCase()
+});
+
+var resultOne = expressionsInstance.compile("'Foo Bar' | transform");
+var resultTwo = anotherExpressionsInstance.compile("'Foo Bar' | transform");
+
+console.log(resultOne()); // prints 'foo bar'
+console.log(resultTwo()); // prints 'FOO BAR'
+```
+
 <br />
 
 ## API
@@ -108,6 +125,22 @@ A cache containing all compiled functions. The src is used as key. Set this on `
 #### .filters = {}
 
 An empty object where you may define your custom filters.
+
+#### .AngularExpressions: Class
+
+Create an instance of the angular-expressions package to isolate the `filters` object by initialized instance.
+
+This allows you to have multiple instances for e.g. multi tenant support.
+
+Example usage:
+```javascript
+var expressionsInstance = new AngularExpressions({
+  uppercase: (input) => input.toUpperCase(),
+  lowercase: (input) => input.toLowerCase(),
+});
+
+var result = expressionsInstance.compile("'Foo Bar' | transform");
+```
 
 #### .Lexer
 

--- a/README.md
+++ b/README.md
@@ -73,21 +73,21 @@ expr({
 }); // returns '1.23€'
 ```
 
-If you need an isolated `filters` object, this can be achieved by creating an instance of the `AngularExpressions` class:
+If you need an isolated `filters` object, this can be achieved by setting the `filters` attribute in the `options` argument. Global cache is disabled if using `options.filters`. To setup an isolated cache, you can also set a `cache` object in the `options` argument. It can then be used to speed up subsequent calls:
 
 ```javascript
-var expressionsInstance = new AngularExpressions({
-  transform: (input) => input.toLowerCase()
-});
-var anotherExpressionsInstance = new AngularExpressions({
-  transform: (input) => input.toUpperCase()
-});
+var isolatedFilters = {
+  transform: (input) => input.toLowerCase(),
+};
+var isolatedCache = {};
 
-var resultOne = expressionsInstance.compile("'Foo Bar' | transform");
-var resultTwo = anotherExpressionsInstance.compile("'Foo Bar' | transform");
+var resultOne = expressions.compile("'Foo Bar' | transform", {
+  filters: isolatedFilters,
+  cache: isolatedCache,
+});
 
 console.log(resultOne()); // prints 'foo bar'
-console.log(resultTwo()); // prints 'FOO BAR'
+console.log(isolatedCache); // print '{"'Foo Bar' | transform": [Function fn] }'
 ```
 
 <br />
@@ -125,22 +125,6 @@ A cache containing all compiled functions. The src is used as key. Set this on `
 #### .filters = {}
 
 An empty object where you may define your custom filters.
-
-#### .AngularExpressions: Class
-
-Create an instance of the angular-expressions package to isolate the `filters` object by initialized an instance.
-
-This allows e.g. multi tenant support.
-
-Example usage:
-```javascript
-var expressionsInstance = new AngularExpressions({
-  uppercase: (input) => input.toUpperCase(),
-  lowercase: (input) => input.toLowerCase(),
-});
-
-var result = expressionsInstance.compile("'Foo Bar' | transform");
-```
 
 #### .Lexer
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ expr({
 }); // returns '1.23€'
 ```
 
-Also if you need independent filter object for e.g. tenant isolation, this can be achieved by creating an instance of the `AngularExpressions` object:
+If you need an isolated `filters` object, this can be achieved by creating an instance of the `AngularExpressions` class:
 
 ```javascript
 var expressionsInstance = new AngularExpressions({
@@ -128,9 +128,9 @@ An empty object where you may define your custom filters.
 
 #### .AngularExpressions: Class
 
-Create an instance of the angular-expressions package to isolate the `filters` object by initialized instance.
+Create an instance of the angular-expressions package to isolate the `filters` object by initialized an instance.
 
-This allows you to have multiple instances for e.g. multi tenant support.
+This allows e.g. multi tenant support.
 
 Example usage:
 ```javascript

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ var resultOne = expressions.compile("'Foo Bar' | transform", {
 });
 
 console.log(resultOne());   // prints 'foo bar'
-console.log(isolatedCache); // print '{"'Foo Bar' | transform": [Function fn] }'
+console.log(isolatedCache); // prints '{"'Foo Bar' | transform": [Function fn] }'
 ```
 
 <br />

--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -42,3 +42,12 @@ export class Parser {
     options?: ParserOptions
   );
 }
+
+export class AngularExpressions {
+  filters: { [x: string]: FilterFunction };
+  cache: { [x: string]: any };
+
+  constructor(filters?: { [x: string]: FilterFunction });
+
+  compile: (tag: string, lexerOptions?: LexerOptions) => EvaluatorFunc;
+}

--- a/lib/main.d.ts
+++ b/lib/main.d.ts
@@ -10,6 +10,19 @@ interface ParserOptions {
   };
 }
 
+interface Filters {
+  [x: string]: FilterFunction;
+}
+
+interface Cache {
+  [x: string]: any;
+}
+
+interface CompileFuncOptions extends LexerOptions {
+  filters?: Filters;
+  cache?: Cache;
+}
+
 type EvaluatorFunc = {
   (scope?: any, context?: any): any;
   ast: any;
@@ -17,10 +30,8 @@ type EvaluatorFunc = {
 };
 
 type CompileFunc = {
-  (tag: string, lexerOptions?: LexerOptions): EvaluatorFunc;
-  cache: {
-    [x: string]: any;
-  };
+  (tag: string, options?: CompileFuncOptions): EvaluatorFunc;
+  cache: Cache;
 };
 
 type FilterFunction = (input: any, ...args: any[]) => any;
@@ -31,9 +42,7 @@ export class Lexer {
   constructor(options?: LexerOptions);
 }
 
-export const filters: {
-  [x: string]: FilterFunction;
-};
+export const filters: Filters;
 
 export class Parser {
   constructor(
@@ -41,13 +50,4 @@ export class Parser {
     filterFunction: (tag: any) => FilterFunction,
     options?: ParserOptions
   );
-}
-
-export class AngularExpressions {
-  filters: { [x: string]: FilterFunction };
-  cache: { [x: string]: any };
-
-  constructor(filters?: { [x: string]: FilterFunction });
-
-  compile: (tag: string, lexerOptions?: LexerOptions) => EvaluatorFunc;
 }

--- a/lib/main.js
+++ b/lib/main.js
@@ -14,7 +14,8 @@ var Parser = parse.Parser;
  * @param {object | undefined} options
  * @returns {function}
  */
-function compile(src, options = {}) {
+function compile(src, options) {
+	options = options || {};
 	var localFilters = options.filters || filters;
 	var cache = options.filters ? (options.cache || {}) : compile.cache;
 	var lexerOptions = options;

--- a/lib/main.js
+++ b/lib/main.js
@@ -85,7 +85,7 @@ compile.cache = Object.create(null);
  */
 var AngularExpressions = (function () {
 	/**
-	 * @param {object | undefined} filters filter object containing the the name (key) function (value) mapping.
+	 * @param {object | undefined} filters
 	 */
 	function AngularExpressions(filters) {
 		this.filters = filters || {};
@@ -106,28 +106,6 @@ var AngularExpressions = (function () {
 
 	return AngularExpressions;
 })();
-
-// class AngularExpressions {
-// 	/**
-// 	 * @param {object | undefined} filters filter object containing the the name (key) function (value) mapping.
-// 	 */
-// 	constructor(filters = {}) {
-// 		this.filters = filters || {};
-// 		this.cache = {};
-// 	}
-
-// 	/**
-// 	 * Compiles src and returns a function that executes src on a target object.
-// 	 * The compiled function is cached under compile.cache[src] to speed up further calls.
-// 	 *
-// 	 * @param {string} src
-// 	 * @param {object | undefined} lexerOptions
-// 	 * @returns {function}
-// 	 */
-// 	compile(src, lexerOptions) {
-// 		return compileFunction(src, this.filters, this.cache, lexerOptions);
-// 	}
-// }
 
 exports.Lexer = Lexer;
 exports.Parser = Parser;

--- a/lib/main.js
+++ b/lib/main.js
@@ -8,16 +8,16 @@ var Parser = parse.Parser;
 
 /**
  * Compiles src and returns a function that executes src on a target object.
- * The compiled function is cached under compile.cache[src] to speed up further calls.
+ * To speed up further calls the compiled function is cached under compile.cache[src] if options.filters is not present.
  *
  * @param {string} src
- * @param {object} filters filter object containing the the name (key) function (value) mapping.
- * @param {object | undefined} cache cache object that should save the compiled function.
- * @param {object | undefined} lexerOptions
+ * @param {object | undefined} options
  * @returns {function}
  */
-function compileFunction(src, filters, cache, lexerOptions) {
-	lexerOptions = lexerOptions || {};
+function compile(src, options = {}) {
+	var localFilters = options.filters || filters;
+	var cache = options.filters ? (options.cache || {}) : compile.cache;
+	var lexerOptions = options;
 
 	var cached;
 
@@ -43,7 +43,7 @@ function compileFunction(src, filters, cache, lexerOptions) {
 	var parser = new Parser(
 		lexer,
 		function getFilter(name) {
-			return filters[name];
+			return localFilters[name];
 		},
 		parserOptions
 	);
@@ -61,18 +61,6 @@ function compileFunction(src, filters, cache, lexerOptions) {
 }
 
 /**
- * Compiles src and returns a function that executes src on a target object.
- * The compiled function is cached under compile.cache[src] to speed up further calls.
- *
- * @param {string} src
- * @param {object | undefined} lexerOptions
- * @returns {function}
- */
-function compile(src, lexerOptions) {
-	return compileFunction(src, filters, compile.cache, lexerOptions);
-}
-
-/**
  * A cache containing all compiled functions. The src is used as key.
  * Set this on false to disable the cache.
  *
@@ -80,35 +68,7 @@ function compile(src, lexerOptions) {
  */
 compile.cache = Object.create(null);
 
-/**
- * Class to enclose the filters object for angular-expressions.
- */
-var AngularExpressions = (function () {
-	/**
-	 * @param {object | undefined} filters
-	 */
-	function AngularExpressions(filters) {
-		this.filters = filters || {};
-		this.cache = {};
-	}
-
-	/**
-	 * Compiles src and returns a function that executes src on a target object.
-	 * The compiled function is cached under compile.cache[src] to speed up further calls.
-	 *
-	 * @param {string} src
-	 * @param {object | undefined} lexerOptions
-	 * @returns {function}
-	 */
-	AngularExpressions.prototype.compile = function (src, lexerOptions) {
-		return compileFunction(src, this.filters, this.cache, lexerOptions);
-	};
-
-	return AngularExpressions;
-})();
-
 exports.Lexer = Lexer;
 exports.Parser = Parser;
 exports.compile = compile;
-exports.AngularExpressions = AngularExpressions;
 exports.filters = filters;

--- a/lib/main.js
+++ b/lib/main.js
@@ -5,14 +5,18 @@ var parse = require("./parse.js");
 var filters = {};
 var Lexer = parse.Lexer;
 var Parser = parse.Parser;
+
 /**
  * Compiles src and returns a function that executes src on a target object.
  * The compiled function is cached under compile.cache[src] to speed up further calls.
  *
  * @param {string} src
+ * @param {object} filters filter object containing the the name (key) function (value) mapping.
+ * @param {object | undefined} cache cache object that should save the compiled function.
+ * @param {object | undefined} lexerOptions
  * @returns {function}
  */
-function compile(src, lexerOptions) {
+function compileFunction(src, filters, cache, lexerOptions) {
 	lexerOptions = lexerOptions || {};
 
 	var cached;
@@ -44,16 +48,28 @@ function compile(src, lexerOptions) {
 		parserOptions
 	);
 
-	if (!compile.cache) {
+	if (!cache) {
 		return parser.parse(src);
 	}
 
-	cached = compile.cache[src];
+	cached = cache[src];
 	if (!cached) {
-		cached = compile.cache[src] = parser.parse(src);
+		cached = cache[src] = parser.parse(src);
 	}
 
 	return cached;
+}
+
+/**
+ * Compiles src and returns a function that executes src on a target object.
+ * The compiled function is cached under compile.cache[src] to speed up further calls.
+ *
+ * @param {string} src
+ * @param {object | undefined} lexerOptions
+ * @returns {function}
+ */
+function compile(src, lexerOptions) {
+	return compileFunction(src, filters, compile.cache, lexerOptions);
 }
 
 /**
@@ -64,7 +80,57 @@ function compile(src, lexerOptions) {
  */
 compile.cache = Object.create(null);
 
+/**
+ * Class to enclose the filters object for angular-expressions.
+ */
+var AngularExpressions = (function () {
+	/**
+	 * @param {object | undefined} filters filter object containing the the name (key) function (value) mapping.
+	 */
+	function AngularExpressions(filters) {
+		this.filters = filters || {};
+		this.cache = {};
+	}
+
+	/**
+	 * Compiles src and returns a function that executes src on a target object.
+	 * The compiled function is cached under compile.cache[src] to speed up further calls.
+	 *
+	 * @param {string} src
+	 * @param {object | undefined} lexerOptions
+	 * @returns {function}
+	 */
+	AngularExpressions.prototype.compile = function (src, lexerOptions) {
+		return compileFunction(src, this.filters, this.cache, lexerOptions);
+	};
+
+	return AngularExpressions;
+})();
+
+// class AngularExpressions {
+// 	/**
+// 	 * @param {object | undefined} filters filter object containing the the name (key) function (value) mapping.
+// 	 */
+// 	constructor(filters = {}) {
+// 		this.filters = filters || {};
+// 		this.cache = {};
+// 	}
+
+// 	/**
+// 	 * Compiles src and returns a function that executes src on a target object.
+// 	 * The compiled function is cached under compile.cache[src] to speed up further calls.
+// 	 *
+// 	 * @param {string} src
+// 	 * @param {object | undefined} lexerOptions
+// 	 * @returns {function}
+// 	 */
+// 	compile(src, lexerOptions) {
+// 		return compileFunction(src, this.filters, this.cache, lexerOptions);
+// 	}
+// }
+
 exports.Lexer = Lexer;
 exports.Parser = Parser;
 exports.compile = compile;
+exports.AngularExpressions = AngularExpressions;
 exports.filters = filters;

--- a/lib/main.test-d.ts
+++ b/lib/main.test-d.ts
@@ -1,5 +1,5 @@
 import expressions from "./main.js";
-import { filters } from "./main.js";
+import { filters, AngularExpressions } from "./main.js";
 
 const { Parser, Lexer } = expressions;
 
@@ -24,7 +24,10 @@ function validChars(ch: string) {
   );
 }
 
+const expressionsInstance = new AngularExpressions();
+
 expressions.compile("être_embarassé", { isIdentifierStart: validChars });
+expressionsInstance.compile("être_embarassé", { isIdentifierStart: validChars });
 
 const cache = expressions.compile.cache;
 const ast = expressions.compile("foobar").ast;

--- a/lib/main.test-d.ts
+++ b/lib/main.test-d.ts
@@ -1,5 +1,5 @@
 import expressions from "./main.js";
-import { filters, AngularExpressions } from "./main.js";
+import { filters } from "./main.js";
 
 const { Parser, Lexer } = expressions;
 
@@ -24,12 +24,16 @@ function validChars(ch: string) {
   );
 }
 
-const expressionsInstance = new AngularExpressions();
-
 expressions.compile("être_embarassé", { isIdentifierStart: validChars });
-expressionsInstance.compile("être_embarassé", { isIdentifierStart: validChars });
 
 const cache = expressions.compile.cache;
 const ast = expressions.compile("foobar").ast;
 
 filters.uppercase = (input: string): string => input.toUpperCase();
+
+expressions.compile("number | square", {
+  filters: {
+    square: (input: number) => input * input,
+  },
+  cache: {}
+});


### PR DESCRIPTION
* allows the isolation of the `filters` object by creating instances of the new `AngularExpressions` class
* added type definitions, tests and updated the README